### PR TITLE
Stricter chrono dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 name = "cron_schedule"
 
 [dependencies]
-chrono = "~0.4"
+chrono = "0.4.19"
 nom = "~4.1"
 once_cell = "1.5.2"


### PR DESCRIPTION
[js-sys](https://crates.io/crates/js-sys/) making wasm not deployable to cosmwasm
```
failed to execute message; message index: 0: Error calling the VM: Error during static Wasm validation: Wasm contract requires unsupported import: "__wbindgen_placeholder__.__wbindgen_describe". Required imports: {"__wbindgen_externref_xform__.__wbindgen_externref_table_grow", "__wbindgen_externref_xform__.__wbindgen_externref_table_set_null", "__wbindgen_placeholder__.__wbindgen_describe", ... 16 more}. Available imports: ["env.abort", "env.db_read", "env.db_write", "env.db_remove", "env.addr_validate", "env.addr_canonicalize", "env.addr_humanize", "env.secp256k1_verify", "env.secp256k1_recover_pubkey", "env.ed25519_verify", "env.ed25519_batch_verify", "env.debug", "env.query_chain", "env.db_scan", "env.db_next"].: create wasm contract failed: invalid request
```
Another option is: disabling default-features https://github.com/chronotope/chrono/pull/771